### PR TITLE
Remove deprecated command

### DIFF
--- a/Formula/tektoncd-cli.rb
+++ b/Formula/tektoncd-cli.rb
@@ -3,7 +3,6 @@ class TektoncdCli < Formula
   desc "Tekton CLI - The command line interface for interacting with Tekton"
   homepage "https://github.com/tektoncd/cli"
   version "0.21.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/tektoncd/cli/releases/download/v0.21.0/tkn_0.21.0_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Currently when installing using Homebrew, we get an deprectation
notice:

    Warning: Calling bottle :unneeded is deprecated!

This patch removes the deprecated command, that now is a no-op.
See e.g. https://stackoverflow.com/questions/45132704/what-does-bottle-unneeded-do

Fixes: #5